### PR TITLE
Update ruff.toml to ignore additional linting rules

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -31,8 +31,12 @@ select = [
 
 ignore = [
     "RUF013",
-    "RUF005"
+    "RUF005",
+    "RUF015"
 ]
+
+[lint.per-file-ignores]
+  "__init__.py" = ["F401"]
 
 [format]
 quote-style = "double"


### PR DESCRIPTION
#17 
- Added RUF015 to the list of ignored rules and specified per-file ignore for F401 in __init__.py.