### PR TITLE
fix(ci): run ARM64 pip-list check with --platform linux/arm64

### DIFF
--- a/.github/workflows/docker-build-arm.yml
+++ b/.github/workflows/docker-build-arm.yml
@@ -158,7 +158,7 @@ jobs:
               run: |
                   echo "## Installed Python Libraries (ARM64)" >> release-notes.txt
                   echo "<pre>" >> release-notes.txt
-                  docker run --rm --entrypoint= "${DOCKER_IMAGE_ID}:${DOCKER_METADATA_OUTPUT_VERSION}" pip list --verbose | grep "${{ inputs.pip_filter }}" >> release-notes.txt
+                  docker run --rm --platform linux/arm64 --entrypoint= "${DOCKER_IMAGE_ID}:${DOCKER_METADATA_OUTPUT_VERSION}" pip list --verbose | grep "${{ inputs.pip_filter }}" >> release-notes.txt
                   echo "</pre>" >> release-notes.txt
 
             - name: Attach docker image to release


### PR DESCRIPTION
## Summary

Fix ARM64 release validation in the shared Docker workflow by running the pip-list container with an explicit ARM64 platform.

This addresses failures like:

- `no matching manifest for linux/amd64 in the manifest list entries`

## What changed

- Updated `workflows/.github/workflows/docker-build-arm.yml`
  - In the `Pip List` step, changed `docker run` to include:
    - `--platform linux/arm64`

## Why

- The ARM workflow builds/pushes an ARM64 image tag (with `-arm64` suffix), but the runner is `larger-runner-x64` (AMD64).  
- Without an explicit platform, `docker run` defaults to AMD64 and fails to resolve the ARM64-only manifest.